### PR TITLE
feat: Implement course overview, department tagging, and new navigation

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -71,6 +71,8 @@ export interface CourseMetadata {
   id: string;
   title: string;
   name: string;
+  department: string;
+  progress: number;
 }
 
 export const fetchAllCourseMetadata = async (): Promise<CourseMetadata[]> => {
@@ -81,7 +83,15 @@ export const fetchAllCourseMetadata = async (): Promise<CourseMetadata[]> => {
     const courses: CourseMetadata[] = [];
     querySnapshot.forEach((doc) => {
       const data = doc.data();
-      courses.push({ id: doc.id, title: data.title || 'Untitled Course', name: data.name || '' });
+      const department = typeof data.department === 'string' ? data.department : 'Uncategorized';
+      const progress = typeof data.progress === 'number' ? data.progress : 0;
+      courses.push({
+        id: doc.id,
+        title: data.title || 'Untitled Course',
+        name: data.name || '',
+        department,
+        progress,
+      });
     });
     return courses;
   } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,5 +22,7 @@ export interface Course {
   materials: string; // JSONContent string
   pacing: string; // JSONContent string
   units: Unit[];
+  department: string;
+  progress: number;
   // any other course-level fields
 }


### PR DESCRIPTION
This commit introduces several enhancements to course management:

1.  **Course Data Enhancement:**
    *   The `Course` data model now includes `department` (string) and `progress` (number, percentage) fields.
    *   These fields are stored in Firebase.
    *   New courses default to "Uncategorized" department and 0% progress.

2.  **Department Tagging:**
    *   You can now edit the department of a course directly in the app header when a course is loaded.
    *   Changes are saved to Firebase and reflected in the navigation menu.

3.  **New Navigation Menu:**
    *   The main navigation in `AppShell.Navbar` has been redesigned.
    *   It now lists courses grouped by their `department`.
    *   Each course entry displays its title and `progress` (e.g., "Course Title (75%)").
    *   Clicking a course loads it into the editor.
    *   The "New Course" action has been moved into this new menu structure.

4.  **Feature Removal:**
    *   The "Compare Documents" feature and its associated UI and state have been removed, simplifying the application.

5.  **UI/State Refinements:**
    *   The `viewMode` state has been removed, with UI logic now primarily driven by the presence of `currentCourse`.
    *   Error handling and loading states have been reviewed and confirmed for consistency.

These changes provide a more organized way to manage and access courses, improve the information density in the navigation, and streamline the overall user experience.